### PR TITLE
Fix /{username} endpoint showing following

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -361,7 +361,7 @@ func UserTimelineHandler(w http.ResponseWriter, r *http.Request) {
 		)
 
 		if err == nil {
-			if queryCheckUserIsFollowed[0]["user_id"] != nil {
+			if len(queryCheckUserIsFollowed) > 0 {
 				follows = true
 			}
 		}


### PR DESCRIPTION
Fixes the issue that was with the /{username} endpoint not setting follows to true if the logged in user is following the user who's page is open

Resolves #40 

/timespend 15m