### PR TITLE
CD: set go version in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v6.2.0
+        with:
+          go-version: '1.25'
       - name: Build binary
         run: "go build -o ./minitwit ./src/main.go"
       - name: Zip project


### PR DESCRIPTION
Fix the small workflow error about not setting go version