### PR TITLE
Fix: Use gorilla sessions to stop global user problem

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -70,8 +70,7 @@ const DEBUG = true
 const SECRET_KEY = "development key"
 
 var g struct {
-	DB   *sql.DB
-	User *User
+	DB *sql.DB
 }
 
 var store = sessions.NewCookieStore([]byte("your-secret-key-here-at-least-32-bytes"))


### PR DESCRIPTION
Fixes the issue of every client interacting with the global state of the server resulting in everyone being on the same user by storing the user as JSON in a gorilla session when then log in, and then using that session to retrieve the user when needed.

Resolves #57 

/timespend 3h