### PR TITLE
fix: Showing that OK link for the root endpoint when not logged in

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -262,7 +262,7 @@ func timeline(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("We got a visitor from: %s\n", r.RemoteAddr)
 	if user == nil {
-		http.Redirect(w, r, "/public", http.StatusOK)
+		http.Redirect(w, r, "/public", http.StatusFound)
 		return
 	}
 	data, err := query_db(`


### PR DESCRIPTION
This changes the status code for the for the `/` endpoint from **OK** to **Found** so that we don't get that link but just do the redirect 

/timespend 1m