### PR TITLE
fix: vagrant provision script issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
       which go
       go version
       
-      mkdir /home/vagrant
+      mkdir -p /home/vagrant
       cp -r /vagrant/* /home/vagrant/
       cd /home/vagrant
 
@@ -87,6 +87,7 @@ Vagrant.configure("2") do |config|
       go mod tidy
       go build -o minitwit ./src
       echo "grab a cup of coffee this step takes a minute"
+      pkill -9 "minitwit" # make sure to kill the process if its currently running
       nohup ./minitwit > app.log 2>&1 &
 
       echo "===================================="


### PR DESCRIPTION
This PR fixes some small issues with the vagrant provision script part. It avoids an error that mkdir would give if the folder already exists and makes sure to kill the already existing process using pkill if minitwit was already running before running the new version


ps. most of the time of this PR is trying to launch and fix the hosted version of the app not the actual vagrant fix
/timespent 1:00 