### PR TITLE
fix: username handlers eat all other endpoints

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -891,14 +891,14 @@ func main() {
 	s := http.StripPrefix("/static/", http.FileServer(http.Dir("./static")))
 	router.HandleFunc("/", timeline).Methods("GET")
 	router.HandleFunc("/public", public).Methods("GET")
-  	router.HandleFunc("/{username}/follow", FollowUserHandler).Methods("GET")
-	router.HandleFunc("/{username}/unfollow", UnfollowUserHandler).Methods("GET")
 	router.HandleFunc("/add_message", addMessage).Methods("POST")
 	router.HandleFunc("/login", login).Methods("GET", "POST")
 	router.HandleFunc("/register-user", register).Methods("GET", "POST")
 	router.HandleFunc("/logout", logoutHandler).Methods("GET")
 	router.PathPrefix("/static/").Handler(s).Methods("GET")
 
+  	router.HandleFunc("/{username}/follow", FollowUserHandler).Methods("GET")
+	router.HandleFunc("/{username}/unfollow", UnfollowUserHandler).Methods("GET")
 	router.HandleFunc("/{username}", UserTimelineHandler).Methods("GET")
 	// defer g.db.Close()
 


### PR DESCRIPTION
This PR is a very small fix to the username handlers. By moving them to the bottom they don't seem to be eating the other endpoints anymore

~~edit: Didn't work I have no idea why behavior on the server is different from local...~~

/timespent 0:15h
