### PR TITLE
fix: Fix ReadTimeout errors from simulator

### DIFF
--- a/src/apimodels/go/api_minitwit_service.go
+++ b/src/apimodels/go/api_minitwit_service.go
@@ -516,7 +516,7 @@ func (s *MinitwitAPIService) PostRegister(ctx context.Context, payload RegisterR
 		}), nil
 	}
 
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), 14)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), 10)
 	if err != nil {
 		return Response(http.StatusInternalServerError, ErrorResponse{
 			Status:   http.StatusInternalServerError,

--- a/src/main.go
+++ b/src/main.go
@@ -205,7 +205,7 @@ func get_user_id(db *sql.DB, username string) (int, error) {
 }
 
 func genereate_password_hash(pass string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(pass), 14)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(pass), 10)
 	return string(bytes), err
 }
 


### PR DESCRIPTION
This lowers the cost of hashing the password when a new user registers from 14 to 10. This reduces the time it takes to generate the hash by an order of magnitude. While technically decreasing security, it's needed to ensure we avoid ReadTimeout errors from the simulator

Resolves #90 

/timespend 45m 