### PR TITLE
test: Run server to run tests against

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -69,8 +69,17 @@ func (m *Ddn) Build(src *dagger.Directory) *dagger.Directory {
 	return outputs
 }
 
+func (m *Ddn) ServerService(src *dagger.Directory) *dagger.Service {
+	return src.DockerBuild().
+		AsService(dagger.ContainerAsServiceOpts{Args: []string{"./main"}})
+}
+
 func (m *Ddn) Test(ctx context.Context, src *dagger.Directory) (string, error) {
-	return m.BuildEnv(src).WithWorkdir("./src").WithExec([]string{"go", "test", "./..."}).Stdout(ctx)
+	return m.BuildEnv(src).
+		WithWorkdir("./src").
+		WithServiceBinding("localhost", m.ServerService(src)).
+		WithExec([]string{"go", "test", "./..."}).
+		Stdout(ctx)
 }
 
 func (m *Ddn) Lint(ctx context.Context, src *dagger.Directory) (string, error) {


### PR DESCRIPTION
This adds a service to the dagger workflow for testing that runs the server build from the dockerfile in the project.

Resolves #92 

/timespend 1h