### PR TITLE
CD/vagrant provision workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,17 @@ jobs:
           verb: call
           module: .
           args: publish --src=. --username=${{ secrets.DOCKER_USERNAME }} --password=DOCKER_PASSWORD
+  provision:
+    needs: publish
+    if: success()
+    name: provision
+    runs-on: macos-latest # Turns out macos comes packaged with vagrant
+    steps: 
+      - name: Setup environment
+        uses: actions/checkout@v4
+      - name: Provision container
+        run: vagrant provision minitwit
+
 
   
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,15 @@ jobs:
       - name: Setup environment
         uses: actions/checkout@v4
       - name: Provision container
+        env:
+          CONTAINER_NAME_PREFIX: "prod"
+          POSTGRES_DB: "minitwit_db"
+          POSTGRES_HOST: "postgres"
+          VOLUME_MOUNT: "/mnt/volume_fra1_01/pgdata"
+          POSTGRES_PORT: "5432"
+          DB_SSL_MODE: "disable"
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         run: vagrant provision minitwit
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,18 @@ jobs:
         uses: actions/setup-go@v6.2.0
         with:
           go-version: '1.25'
-      - name: Build binary
-        run: "go build -o ./minitwit ./src/main.go"
+      - name: Build binaries
+        uses: dagger/dagger-for-github@v8.3.0
+        with:
+          version: "latest"
+          verb: call
+          module: .
+          args: build --src=. export --path=./tmp 
       - name: Zip project
-        run: "tar -zcvf minitwit.tar.gz minitwit README.md static templates"
+        run: |
+          "for dir in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
+            tar -zcvf "${dir}.tar.gz" -C tmp/build "$dir"
+          done"
       - name: Auto Changelog
         uses: ardalanamini/auto-changelog@v4.0.1
         id  : changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup environment
         uses: actions/checkout@v4
       - name: Test
-        uses: dagger/dagger-for-github@v8.3.0
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77
         with:
           module: .
           args: test --src=.    
@@ -29,7 +29,7 @@ jobs:
         with:
           go-version: '1.25'
       - name: Build binaries
-        uses: dagger/dagger-for-github@v8.3.0
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77
         with:
           version: "latest"
           verb: call
@@ -75,7 +75,7 @@ jobs:
       - name: Setup environment
         uses: actions/checkout@v4
       - name: Publish
-        uses: dagger/dagger-for-github@v8.3.0
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main   
 
+
+
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -15,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run quality checks
-        uses: dagger/dagger-for-github@v8.3.0
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77
         with:
           module: .
           args: quality --src=.         
@@ -25,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4           
       - name: Run tests
-        uses: dagger/dagger-for-github@v8.3.0
+        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77
         with:
           module: .
           args: test --src=.        


### PR DESCRIPTION
This PR includes an addition to the release workflow which upon a succesful deployment of the new docker image to dockerhub will run the provision vagrant script to provision the new image to the running droplet. The repo still needs the DO token and the ssh key that is tied to the droplet but I will do this later. This PR should not be merged until the vagrant fix PR has been merged otherwise we risk blowing up the entire database on the hosted droplet :) 

/timespent 01:11h @Slug-Boi

Resolves #148
