### PR TITLE
feature/reuse db connection

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -3,17 +3,17 @@ services:
     image: postgres:15-alpine
     container_name: minitwit-postgres
     environment:
-      POSTGRES_USER: 
-      POSTGRES_PASSWORD: 
-      POSTGRES_DB: minitwit_db
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:5432"
     networks:
       - minitwit-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U minitwit_user -d minitwit_db"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -32,7 +32,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/prometheus_local.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
     networks:
@@ -75,7 +75,7 @@ services:
           memory: 128M
 
   minitwit:
-    image: minitwit-monitoring:latest
+    image: minitwitutmimage:latest
     # ports:
     #   - "8080:8080"
     # SWARM PORTS (uncomment for swarm deployment, comment out local ports above)
@@ -87,13 +87,13 @@ services:
     networks:
       - minitwit-network
     environment:
-      - DATABASE_URL=postgresql://_:_@postgres:5432/minitwit_db?sslmode=disable
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
     depends_on:
       - postgres
     restart: unless-stopped
     deploy:
       mode: replicated
-      replicas: 3
+      replicas: 1
       restart_policy:
         condition: on-failure
         delay: 5s

--- a/src/apimodels/go/api_minitwit_service.go
+++ b/src/apimodels/go/api_minitwit_service.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,6 +31,12 @@ const (
 )
 
 var latestValue int64
+
+var (
+	apiDB     *sql.DB
+	apiDBErr  error
+	apiDBInit sync.Once
+)
 
 func updateLatestIfProvided(latest int32) {
 	if latest <= 0 {
@@ -66,7 +73,22 @@ func getAPIDatabaseDSN() string {
 }
 
 func openDB() (*sql.DB, error) {
-	return sql.Open("postgres", getAPIDatabaseDSN())
+	// Use sync.Once to ensure that the database connection is initialized only once.
+	// This allows us to reuse the same connection for subsequent requests, improving performance and resource utilization.
+	apiDBInit.Do(func() {
+		apiDB, apiDBErr = sql.Open("postgres", getAPIDatabaseDSN())
+		if apiDBErr != nil {
+			return
+		}
+
+		if err := apiDB.Ping(); err != nil {
+			apiDBErr = err
+			_ = apiDB.Close()
+			apiDB = nil
+		}
+	})
+
+	return apiDB, apiDBErr
 }
 
 func getUserID(db *sql.DB, username string) (int64, error) {
@@ -110,7 +132,6 @@ func (s *MinitwitAPIService) GetFollow(ctx context.Context, username string, aut
 			ErrorMsg: err.Error(),
 		}), nil
 	}
-	defer db.Close()
 
 	userID, err := getUserID(db, username)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -173,7 +194,6 @@ func (s *MinitwitAPIService) PostFollow(ctx context.Context, username string, au
 			ErrorMsg: err.Error(),
 		}), nil
 	}
-	defer db.Close()
 
 	userID, err := getUserID(db, username)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -289,7 +309,6 @@ func (s *MinitwitAPIService) GetMessages(ctx context.Context, authorization stri
 			ErrorMsg: err.Error(),
 		}), nil
 	}
-	defer db.Close()
 
 	rows, err := db.Query(`
 		select message.text, message.pub_date, u.username
@@ -359,7 +378,6 @@ func (s *MinitwitAPIService) GetMessagesPerUser(ctx context.Context, username st
 			ErrorMsg: err.Error(),
 		}), nil
 	}
-	defer db.Close()
 
 	userID, err := getUserID(db, username)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -435,7 +453,6 @@ func (s *MinitwitAPIService) PostMessagesPerUser(ctx context.Context, username s
 			ErrorMsg: err.Error(),
 		}), nil
 	}
-	defer db.Close()
 
 	userID, err := getUserID(db, username)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -506,19 +523,6 @@ func (s *MinitwitAPIService) PostRegister(ctx context.Context, payload RegisterR
 			ErrorMsg: err.Error(),
 		}), nil
 	}
-	defer db.Close()
-
-	if _, err := getUserID(db, username); err == nil {
-		return Response(http.StatusBadRequest, ErrorResponse{
-			Status:   http.StatusBadRequest,
-			ErrorMsg: "The username is already taken",
-		}), nil
-	} else if !errors.Is(err, sql.ErrNoRows) {
-		return Response(http.StatusInternalServerError, ErrorResponse{
-			Status:   http.StatusInternalServerError,
-			ErrorMsg: err.Error(),
-		}), nil
-	}
 
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), 10)
 	if err != nil {
@@ -528,15 +532,32 @@ func (s *MinitwitAPIService) PostRegister(ctx context.Context, payload RegisterR
 		}), nil
 	}
 
-	if _, err := db.Exec(
-		`insert into "user" (username, email, pw_hash) values ($1, $2, $3)`,
+	result, err := db.Exec(
+		`insert into "user" (username, email, pw_hash)
+		 values ($1, $2, $3)
+		 on conflict (username) do nothing`,
 		username,
 		email,
 		string(passwordHash),
-	); err != nil {
+	)
+	if err != nil {
 		return Response(http.StatusInternalServerError, ErrorResponse{
 			Status:   http.StatusInternalServerError,
 			ErrorMsg: err.Error(),
+		}), nil
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return Response(http.StatusInternalServerError, ErrorResponse{
+			Status:   http.StatusInternalServerError,
+			ErrorMsg: err.Error(),
+		}), nil
+	}
+	if rowsAffected == 0 {
+		return Response(http.StatusBadRequest, ErrorResponse{
+			Status:   http.StatusBadRequest,
+			ErrorMsg: "The username is already taken",
 		}), nil
 	}
 

--- a/src/db/db.go
+++ b/src/db/db.go
@@ -12,19 +12,19 @@ import (
 var DB *gorm.DB
 
 func shouldMigrate(db *gorm.DB) bool {
-    m := db.Migrator()
+	m := db.Migrator()
 
-    if !m.HasTable(&model.User{}) || !m.HasTable(&model.Message{}) || !m.HasTable(&model.Follower{}) {
-        return true
-    }
+	if !m.HasTable(&model.User{}) || !m.HasTable(&model.Message{}) || !m.HasTable(&model.Follower{}) {
+		return true
+	}
 
-    if !m.HasColumn(&model.User{}, "pw_hash") ||
-       !m.HasColumn(&model.Message{}, "pub_date") ||
-       !m.HasColumn(&model.Message{}, "flagged") {
-        return true
-    }
+	if !m.HasColumn(&model.User{}, "pw_hash") ||
+		!m.HasColumn(&model.Message{}, "pub_date") ||
+		!m.HasColumn(&model.Message{}, "flagged") {
+		return true
+	}
 
-    return false
+	return false
 }
 
 func Connect(dsn string) (*gorm.DB, error) {
@@ -45,15 +45,24 @@ func Connect(dsn string) (*gorm.DB, error) {
 		time.Sleep(time.Second * 5)
 	}
 
-  log.Println("Running migrations...")
-  if shouldMigrate(DB) {
-    err := DB.AutoMigrate(&model.User{}, &model.Message{}, &model.Follower{})
-    if err != nil {
-        log.Printf("Failed to run migrations: %s", err.Error())
-        return nil, err
-    }
-    log.Println("Migrations complete")
-  }
-  
+	log.Println("Running migrations...")
+	if shouldMigrate(DB) {
+		err := DB.AutoMigrate(&model.User{}, &model.Message{}, &model.Follower{})
+		if err != nil {
+			log.Printf("Failed to run migrations: %s", err.Error())
+			return nil, err
+		}
+	}
+
+	if !DB.Migrator().HasIndex(&model.User{}, "idx_user_username") {
+		err := DB.Migrator().CreateIndex(&model.User{}, "Username")
+		if err != nil {
+			log.Printf("Failed to create username unique index: %s", err.Error())
+			return nil, err
+		}
+	}
+
+	log.Println("Migrations complete")
+
 	return DB, nil
 }

--- a/src/model/model.go
+++ b/src/model/model.go
@@ -1,38 +1,38 @@
 package model
 
 type User struct {
-    UserID   uint   `gorm:"primaryKey;autoIncrement;column:user_id"`
-    Username string `gorm:"not null;column:username"`
-    Email    string `gorm:"not null;column:email"`
-    PwHash   string `gorm:"not null;column:pw_hash"`
-    
-    Messages  []Message `gorm:"foreignKey:AuthorID"`
-    Followers []Follower `gorm:"foreignKey:WhoID"`
-    Following []Follower `gorm:"foreignKey:WhomID"`
+	UserID   uint   `gorm:"primaryKey;autoIncrement;column:user_id"`
+	Username string `gorm:"not null;uniqueIndex:idx_user_username;column:username"`
+	Email    string `gorm:"not null;column:email"`
+	PwHash   string `gorm:"not null;column:pw_hash"`
+
+	Messages  []Message  `gorm:"foreignKey:AuthorID"`
+	Followers []Follower `gorm:"foreignKey:WhoID"`
+	Following []Follower `gorm:"foreignKey:WhomID"`
 }
 
 func (User) TableName() string {
-    return "user"
+	return "user"
 }
 
 type Follower struct {
-    WhoID  uint `gorm:"column:who_id;index:idx_follower_who"`
-    WhomID uint `gorm:"column:whom_id;index:idx_follower_whom"`
+	WhoID  uint `gorm:"column:who_id;index:idx_follower_who"`
+	WhomID uint `gorm:"column:whom_id;index:idx_follower_whom"`
 }
 
 func (Follower) TableName() string {
-    return "follower"
+	return "follower"
 }
 
 type Message struct {
-    MessageID uint   `gorm:"primaryKey;autoIncrement;column:message_id"`
-    AuthorID  uint   `gorm:"not null;column:author_id;index:idx_message_author"`
-    Author    User   `gorm:"foreignKey:AuthorID"`
-    Text      string `gorm:"not null;column:text"`
-    PubDate   int64  `gorm:"column:pub_date"`
-    Flagged   int    `gorm:"column:flagged;default:0"`
+	MessageID uint   `gorm:"primaryKey;autoIncrement;column:message_id"`
+	AuthorID  uint   `gorm:"not null;column:author_id;index:idx_message_author"`
+	Author    User   `gorm:"foreignKey:AuthorID"`
+	Text      string `gorm:"not null;column:text"`
+	PubDate   int64  `gorm:"column:pub_date"`
+	Flagged   int    `gorm:"column:flagged;default:0"`
 }
 
 func (Message) TableName() string {
-    return "message"
+	return "message"
 }


### PR DESCRIPTION
MERGE AFTER PR #168 (Change local compose to use env variables & only 1 replica of minitwit)

This is made in an attempt to make /register endpoint faster by only doing 1 DB request instead of 2 as well as making all minitwit endpoints a bit faster.

- **Change local compose to use env variables & only 1 replica of minitwit**
- **Reuse DB connection & do a single db call when registering new user**
