### PR TITLE
refactor/add latest to db

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -90,6 +90,7 @@ services:
 
   minitwit:
     image: minitwitutmimage:latest
+    build: .
     # ports:
     #   - "8080:8080"
     # SWARM PORTS (uncomment for swarm deployment, comment out local ports above)

--- a/src/apimodels/go/api_minitwit_service.go
+++ b/src/apimodels/go/api_minitwit_service.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"minitwit/src/repository"
+
 	_ "github.com/lib/pq"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -38,16 +40,11 @@ var (
 	apiDBInit sync.Once
 )
 
-func updateLatestIfProvided(latest int32) {
-	if latest <= 0 {
+func (s *MinitwitAPIService) updateLatestIfProvided(latest int32) {
+	err := s.latestRepo.UpdateLatest(latest)
+	if err != nil { // TODO: add error handling
 		return
-	}
-	for {
-		current := atomic.LoadInt64(&latestValue)
-		if atomic.CompareAndSwapInt64(&latestValue, current, int64(latest)) {
-			return
-		}
-	}
+	}       
 }
 
 func getLatest() int32 {
@@ -105,11 +102,14 @@ func formatMessageTime(unixTimestamp int64) string {
 // This service should implement the business logic for every endpoint for the MinitwitAPI API.
 // Include any external packages or services that will be required by this service.
 type MinitwitAPIService struct {
+	latestRepo *repository.LatestRepository
 }
 
 // NewMinitwitAPIService creates a default api service
-func NewMinitwitAPIService() *MinitwitAPIService {
-	return &MinitwitAPIService{}
+func NewMinitwitAPIService(latestRepo *repository.LatestRepository) *MinitwitAPIService {
+	return &MinitwitAPIService{
+		latestRepo: latestRepo,
+	}
 }
 
 // GetFollow -
@@ -119,7 +119,7 @@ func (s *MinitwitAPIService) GetFollow(ctx context.Context, username string, aut
 	if !isAuthorized(authorization) {
 		return unauthorizedResponse()
 	}
-	updateLatestIfProvided(latest)
+	s.updateLatestIfProvided(latest)
 
 	if no < 0 {
 		no = 0
@@ -185,7 +185,7 @@ func (s *MinitwitAPIService) PostFollow(ctx context.Context, username string, au
 	if !isAuthorized(authorization) {
 		return unauthorizedResponse()
 	}
-	updateLatestIfProvided(latest)
+	s.updateLatestIfProvided(latest)
 
 	db, err := openDB()
 	if err != nil {
@@ -287,7 +287,11 @@ func (s *MinitwitAPIService) PostFollow(ctx context.Context, username string, au
 
 // GetLatestValue -
 func (s *MinitwitAPIService) GetLatestValue(ctx context.Context) (ImplResponse, error) {
-	return Response(http.StatusOK, LatestValue{Latest: getLatest()}), nil
+	latest, err := s.latestRepo.GetLatest()
+	if err != nil {
+		return Response(http.StatusInternalServerError, nil), err
+	}
+	return Response(http.StatusOK, LatestValue{Latest: latest}), nil
 }
 
 // GetMessages -
@@ -296,7 +300,7 @@ func (s *MinitwitAPIService) GetMessages(ctx context.Context, authorization stri
 	if !isAuthorized(authorization) {
 		return unauthorizedResponse()
 	}
-	updateLatestIfProvided(latest)
+	s.updateLatestIfProvided(latest)
 
 	if no < 0 {
 		no = 0
@@ -365,7 +369,7 @@ func (s *MinitwitAPIService) GetMessagesPerUser(ctx context.Context, username st
 	if !isAuthorized(authorization) {
 		return unauthorizedResponse()
 	}
-	updateLatestIfProvided(latest)
+	s.updateLatestIfProvided(latest)
 
 	if no < 0 {
 		no = 0
@@ -444,7 +448,7 @@ func (s *MinitwitAPIService) PostMessagesPerUser(ctx context.Context, username s
 	if !isAuthorized(authorization) {
 		return unauthorizedResponse()
 	}
-	updateLatestIfProvided(latest)
+	s.updateLatestIfProvided(latest)
 
 	db, err := openDB()
 	if err != nil {
@@ -491,7 +495,7 @@ func (s *MinitwitAPIService) PostMessagesPerUser(ctx context.Context, username s
 // PostRegister -
 func (s *MinitwitAPIService) PostRegister(ctx context.Context, payload RegisterRequest, latest int32) (ImplResponse, error) {
 	// TODO: Add api_minitwit_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	updateLatestIfProvided(latest)
+	s.updateLatestIfProvided(latest)
 
 	username := strings.TrimSpace(payload.Username)
 	email := strings.TrimSpace(payload.Email)

--- a/src/db/db.go
+++ b/src/db/db.go
@@ -47,7 +47,7 @@ func Connect(dsn string) (*gorm.DB, error) {
 
 	log.Println("Running migrations...")
 	if shouldMigrate(DB) {
-		err := DB.AutoMigrate(&model.User{}, &model.Message{}, &model.Follower{})
+		err := DB.AutoMigrate(&model.User{}, &model.Message{}, &model.Follower{}, &model.Latest{})
 		if err != nil {
 			log.Printf("Failed to run migrations: %s", err.Error())
 			return nil, err

--- a/src/db/db.go
+++ b/src/db/db.go
@@ -14,13 +14,14 @@ var DB *gorm.DB
 func shouldMigrate(db *gorm.DB) bool {
 	m := db.Migrator()
 
-	if !m.HasTable(&model.User{}) || !m.HasTable(&model.Message{}) || !m.HasTable(&model.Follower{}) {
+	if !m.HasTable(&model.User{}) || !m.HasTable(&model.Message{}) || !m.HasTable(&model.Follower{}) || !m.HasTable(&model.Latest{}) {
 		return true
 	}
 
 	if !m.HasColumn(&model.User{}, "pw_hash") ||
 		!m.HasColumn(&model.Message{}, "pub_date") ||
-		!m.HasColumn(&model.Message{}, "flagged") {
+		!m.HasColumn(&model.Message{}, "flagged") ||
+		!m.HasColumn(&model.Latest{}, "latest")	{
 		return true
 	}
 
@@ -47,7 +48,7 @@ func Connect(dsn string) (*gorm.DB, error) {
 
 	log.Println("Running migrations...")
 	if shouldMigrate(DB) {
-		err := DB.AutoMigrate(&model.User{}, &model.Message{}, &model.Follower{})
+		err := DB.AutoMigrate(&model.User{}, &model.Message{}, &model.Follower{}, &model.Latest{})
 		if err != nil {
 			log.Printf("Failed to run migrations: %s", err.Error())
 			return nil, err

--- a/src/main.go
+++ b/src/main.go
@@ -89,6 +89,7 @@ var GormDB *gorm.DB
 var UserRepo *repository.UserRepository
 var MessageRepo *repository.MessageRepository
 var FollowerRepo *repository.FollowerRepository
+var LatestRepo *repository.LatestRepository
 
 func renderTimelineTemplate(w http.ResponseWriter, data TimelineData) error {
 	tmpl, err := template.New("layout.html").
@@ -849,12 +850,6 @@ func main() {
 		SameSite: http.SameSiteLaxMode,
 	}
 
-	MinitwitAPIService := openapi.NewMinitwitAPIService()
-	MinitwitAPIController := openapi.NewMinitwitAPIController(MinitwitAPIService)
-
-	router := openapi.NewRouter(MinitwitAPIController)
-	router.Use(monitor.MetricsMiddleware(monitor.NewMetrics(reg)))
-
 	// Check if DATABASE_URL is set in environment first
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
@@ -875,10 +870,19 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to connect to database with GORM:", err)
 	}
+
 	// Initialize repositories
 	UserRepo = repository.NewUserRepository(GormDB)
 	MessageRepo = repository.NewMessageRepository(GormDB)
 	FollowerRepo = repository.NewFollowerRepository(GormDB)
+	LatestRepo = repository.NewLatestRepository(GormDB)
+
+	MinitwitAPIService := openapi.NewMinitwitAPIService(LatestRepo)
+	MinitwitAPIController := openapi.NewMinitwitAPIController(MinitwitAPIService)
+
+	router := openapi.NewRouter(MinitwitAPIController)
+	router.Use(monitor.MetricsMiddleware(monitor.NewMetrics(reg)))
+	
 	// Seed database with initial data if empty
 	var userCount int64
 	GormDB.Model(&model.User{}).Count(&userCount)

--- a/src/model/model.go
+++ b/src/model/model.go
@@ -38,7 +38,7 @@ func (Message) TableName() string {
 }
 
 type Latest struct {
-	Latest uint		`gorm:"primaryKey;autoIncrement;column:latest"`
+	Latest int32		`gorm:"primaryKey;autoIncrement;column:latest"`
 }
 
 func (Latest) TableName() string {

--- a/src/model/model.go
+++ b/src/model/model.go
@@ -36,3 +36,11 @@ type Message struct {
 func (Message) TableName() string {
 	return "message"
 }
+
+type Latest struct {
+	Latest uint		`gorm:"primaryKey;autoIncrement;column:latest"`
+}
+
+func (Latest) TableName() string {
+	return "latest"
+}

--- a/src/repository/latest.go
+++ b/src/repository/latest.go
@@ -13,7 +13,7 @@ func NewLatestRepository(database *gorm.DB) *LatestRepository {
     return &LatestRepository{db: database}
 }
 
-func (r *LatestRepository) GetLatest() (uint, error) {
+func (r *LatestRepository) GetLatest() (int32, error) {
     var latest model.Latest
     result := r.db.First(&latest)
     if result.Error != nil {
@@ -22,19 +22,31 @@ func (r *LatestRepository) GetLatest() (uint, error) {
     return latest.Latest, nil
 }
 
-func (r *LatestRepository) IncrementLatest() (uint, error) {
-    var latest model.Latest
-    
-    result := r.db.First(&latest)
-    if result.Error != nil {
-        return 0, result.Error
-    }
-    latest.Latest++
-    
-    result = r.db.Save(&latest)
-    if result.Error != nil {
-        return 0, result.Error
+func (r *LatestRepository) UpdateLatest(latest int32) error {
+        if latest <= 0 {
+        return nil
     }
     
-    return latest.Latest, nil
+    for {
+        // Get current value
+        current, err := r.GetLatest()
+        if err != nil {
+            return err
+        }
+        
+        // Try to update value
+		// Unsure if this where check is needed
+        result := r.db.Model(&model.Latest{}).
+            Where("latest = ?", current).
+            Update("latest", latest)
+        
+        if result.Error != nil {
+            return result.Error
+        }
+        
+        // Updated row = success
+        if result.RowsAffected > 0 {
+            return nil
+        }   
+    }
 }

--- a/src/repository/latest.go
+++ b/src/repository/latest.go
@@ -1,52 +1,62 @@
 package repository
 
 import (
-    "minitwit/src/model"
-    "gorm.io/gorm"
+	"errors"
+	"log"
+	"minitwit/src/model"
+
+	"gorm.io/gorm"
 )
 
-type LatestRepository struct{
-    db *gorm.DB
+type LatestRepository struct {
+	db *gorm.DB
 }
 
 func NewLatestRepository(database *gorm.DB) *LatestRepository {
-    return &LatestRepository{db: database}
+	return &LatestRepository{db: database}
 }
 
 func (r *LatestRepository) GetLatest() (int32, error) {
-    var latest model.Latest
-    result := r.db.First(&latest)
-    if result.Error != nil {
-        return 0, result.Error
-    }
-    return latest.Latest, nil
+	var latest model.Latest
+	result := r.db.First(&latest)
+	if result.Error != nil {
+		return -1, result.Error
+	}
+	return latest.Latest, nil
 }
 
 func (r *LatestRepository) UpdateLatest(latest int32) error {
-        if latest <= 0 {
-        return nil
-    }
+	if latest < 0 {
+		log.Println("Latest lower than 0")
+		return nil
+	}
+
+	// Get current value
+	current, err := r.GetLatest()
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	if current == -1 {
+		result := r.db.Create(&model.Latest{Latest: latest})
+		if result.Error != nil {
+			return result.Error
+		}
+		return nil
+	}
+
+	// Try to update value
+	// Unsure if this where check is needed
+	result := r.db.Model(&model.Latest{}).
+		Where("latest = ?", current).
+		Update("latest", latest)
+
+	if result.Error != nil {
+		return result.Error
+	}
     
-    for {
-        // Get current value
-        current, err := r.GetLatest()
-        if err != nil {
-            return err
-        }
-        
-        // Try to update value
-		// Unsure if this where check is needed
-        result := r.db.Model(&model.Latest{}).
-            Where("latest = ?", current).
-            Update("latest", latest)
-        
-        if result.Error != nil {
-            return result.Error
-        }
-        
-        // Updated row = success
-        if result.RowsAffected > 0 {
-            return nil
-        }   
-    }
+	// Updated row = success
+	if result.RowsAffected > 0 {
+		return nil
+	}
+	return nil
 }

--- a/src/repository/latest.go
+++ b/src/repository/latest.go
@@ -17,7 +17,7 @@ func (r *LatestRepository) GetLatest() (int32, error) {
     var latest model.Latest
     result := r.db.First(&latest)
     if result.Error != nil {
-        return 0, result.Error
+        return -1, result.Error
     }
     return latest.Latest, nil
 }
@@ -32,6 +32,11 @@ func (r *LatestRepository) UpdateLatest(latest int32) error {
         current, err := r.GetLatest()
         if err != nil {
             return err
+        }
+
+        if current == -1 {
+            result := r.db.Model(&model.Latest{}).Create(&model.Latest{Latest: latest})
+            return result.Error
         }
         
         // Try to update value

--- a/src/repository/latest.go
+++ b/src/repository/latest.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+    "minitwit/src/model"
+    "gorm.io/gorm"
+)
+
+type LatestRepository struct{
+    db *gorm.DB
+}
+
+func NewLatestRepository(database *gorm.DB) *LatestRepository {
+    return &LatestRepository{db: database}
+}
+
+func (r *LatestRepository) GetLatest() (uint, error) {
+    var latest model.Latest
+    result := r.db.First(&latest)
+    if result.Error != nil {
+        return 0, result.Error
+    }
+    return latest.Latest, nil
+}
+
+func (r *LatestRepository) IncrementLatest() (uint, error) {
+    var latest model.Latest
+    
+    result := r.db.First(&latest)
+    if result.Error != nil {
+        return 0, result.Error
+    }
+    latest.Latest++
+    
+    result = r.db.Save(&latest)
+    if result.Error != nil {
+        return 0, result.Error
+    }
+    
+    return latest.Latest, nil
+}


### PR DESCRIPTION
This PR should allow for the latest value to be stored in the db and thus persist beyond program restarts. The PR adds latest as a new table to the db and adds a bunch of changes to the api endpoints. I noticed that the current api service handlers do not use the gorm specified models or functions so this needs to be updated as well at some point to make the system a bit more uniform. 

Resolves #82

/timespent 03:00h @Slug-Boi 
/timespent 02:00h @August-Brandt 
