### PR TITLE
chore: add mailmap file to map authors to a unified github user

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+August-Brandt <augustbrandt170@gmail.com> August Kofoed Brandt <augustbrandt170@gmail.com>
+Copilot <175728472+Copilot@users.noreply.github.com> fromchatgpt <openai-chatgpt@git-acme.xyz>
+Copilot Autofix <175728472+Copilot@users.noreply.github.com>
+OpenAI's ChatGPT <175728472+Copilot@users.noreply.github.com>
+Emilia-Victoria <emiliav.helsted@gmail.com> Emilia <emiliav.helsted@gmail.com>
+Emilia-Victoria <emiliav.helsted@gmail.com> Emilia-Victoria <82033720+Emilia-Victoria@users.noreply.github.com>
+Flakiator <niklaschristensen2002@gmail.com> Niklas <nizc@itu.dk>
+Flakiator <niklaschristensen2002@gmail.com> Niklas Christensen <Flakiator@users.noreply.github.com>
+Philip <phgp@itu.dk> Philipnah <phgp@itu.dk>
+Philip <phgp@itu.dk> Philip Han <46556419+Philipnah@users.noreply.github.com>
+Slug-Boi <github.unshipped609@slmail.me> Slug-Boi <theis.p.holm@gmail.com>
+Slug-Boi <github.unshipped609@slmail.me> Theis <112340858+Slug-Boi@users.noreply.github.com>
+Slug-Boi <github.unshipped609@slmail.me> Theis <Slug-Boi@users.noreply.github.com>


### PR DESCRIPTION
This PR includes the mailmap file we were asked to create. Please double check that the username and or email is the one you actually want refered to if not please push a change to the branch. The left hand username and email is the one that will be refered to. This PR will be merged once all have reviewed to make sure its actually correct

/timespent 01:00h @Slug-Boi 
