### PR TITLE
refactor: add logging to token parsing and request finish

### DIFF
--- a/src/authentication/middleware.go
+++ b/src/authentication/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"time"
 )
 
 type contextKey string
@@ -13,13 +14,18 @@ const UserKey contextKey = "user"
 // If valid jwt exists then adds user to request context with key "user".
 func RequiredAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()	
+
+		log.Printf("%s %s Unauthorized Request (no token)", r.Method, r.RequestURI)
 		cookie, err := r.Cookie("token")
 		if err != nil {
 			log.Printf("%s %s Unauthorized Request (no token)", r.Method, r.RequestURI)
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
+		log.Printf("Started parsing token (elapsed: %.3f ms)", float64(time.Since(start).Microseconds())/1000)
 		claims, err := ParseToken(cookie.Value)
+		log.Printf("Done parsing token (elapsed: %.3f ms)", float64(time.Since(start).Microseconds())/1000)
 		if err != nil {
 			log.Printf("%s %s Unauthorized Request (invalid token): %s", r.Method, r.RequestURI, err.Error())
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
@@ -31,6 +37,7 @@ func RequiredAuth(next http.Handler) http.Handler {
 			Email:    claims.Email,
 		}
 		ctx := context.WithValue(r.Context(), UserKey, user)
+		log.Printf("Request finished (elapsed: %.3f ms)", float64(time.Since(start).Microseconds())/1000)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -39,7 +46,11 @@ func RequiredAuth(next http.Handler) http.Handler {
 // if valid jwt exists. Otherwise just executes next handler.
 func OptionalAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		log.Printf("Started parsing token (elapsed: %.3f ms)", float64(time.Since(start).Microseconds())/1000)
 		cookie, err := r.Cookie("token")
+		log.Printf("Done parsing token (elapsed: %.3f ms)", float64(time.Since(start).Microseconds())/1000)
 		if err == nil {
 			if claims, err := ParseToken(cookie.Value); err == nil {
 				user := &User{
@@ -51,6 +62,7 @@ func OptionalAuth(next http.Handler) http.Handler {
 				r = r.WithContext(ctx)
 			}
 		}
+		log.Printf("Request finished (elapsed: %.3f ms)", float64(time.Since(start).Microseconds())/1000)
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
This PR adds logging to token parsing to check if this is the slow part
