### PR TITLE
ci: exclude playwright tests in sonarqube as they contribute a massive amount of security and code dup

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.exclusions=docker-compose*.yml
+sonar.exclusions=docker-compose*.yml,tests/**/*


### PR DESCRIPTION
these are false flags so we should just ignore the files to make sonarqube happy

/timespent 0:05h @Slug-Boi
